### PR TITLE
Add support for SDCARD image compression

### DIFF
--- a/classes/image_types_fsl.bbclass
+++ b/classes/image_types_fsl.bbclass
@@ -319,7 +319,8 @@ IMAGE_CMD_sdcard () {
 	dd if=/dev/zero of=${SDCARD} bs=1 count=0 seek=$(expr 1024 \* ${SDCARD_SIZE})
 
 	${SDCARD_GENERATION_COMMAND}
-		# Optionally apply compression
+	
+	# Optionally apply compression
 	case "${SDCARD_COMPRESSION}" in
 	"gzip")
 		gzip -k9 "${SDCARD}"


### PR DESCRIPTION
Compression method to apply to SDCARD after it has been created. 
Supported compression formats are "gzip", "bzip2" or "xz". 
The original .sdcard file is kept and a new compressed file is created if one of these compression
formats is chosen. 
If SDCARD_COMPRESSION is set to any other value it is silently ignored.
SDCARD_COMPRESSION ?= variable can be set in local.conf
